### PR TITLE
Fix Script for Ubuntu 15.04

### DIFF
--- a/Unreal_Engine_Install_Script.sh
+++ b/Unreal_Engine_Install_Script.sh
@@ -6,7 +6,7 @@ sudo apt-get update; sudo apt-get dist-upgrade -y
 
 # Installing Dependencies
 echo "Installing dependencies..."
-sudo apt-get install -y build-essential mono-{xbuild,dmcs,gmcs} libmono-{corlib4.0,system-data-datasetextensions4.0-cil,system-web-extensions4.0-cil,system-management4.0-cil,system-xml-linq4.0-cil} cmake dos2unix clang xdg-user-dirs libqt4-dev git
+sudo apt-get install -y build-essential mono-{xbuild,dmcs,gmcs} libmono-{corlib4.0,system-data-datasetextensions4.0-cil,system-web-extensions4.0-cil,system-management4.0-cil,system-xml-linq4.0-cil,microsoft-build-tasks-v4.0-4.0-cil} cmake dos2unix clang xdg-user-dirs libqt4-dev git
 
 # Obtain Source
 echo "Obtaining source through Github..."

--- a/Unreal_Engine_Install_Script.sh
+++ b/Unreal_Engine_Install_Script.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 ## Unreal Engine Install Script Version 1.0 Ubuntu Derivatives
 # Check for updates
 echo "Checking for updates..."

--- a/Unreal_Engine_Install_Script.sh
+++ b/Unreal_Engine_Install_Script.sh
@@ -1,21 +1,23 @@
-#Unrela Engine Install Script Version 1.0 Ubuntu Derivatives
+#!/bin/sh
+## Unreal Engine Install Script Version 1.0 Ubuntu Derivatives
+# Check for updates
+echo "Checking for updates..."
+sudo apt-get update; sudo apt-get dist-upgrade -y
 
-echo Installing depenancies: &&
-#Dependacies
-sudo apt-get install mono-mcs && sudo apt-get install mono-gmcs && sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF && echo "deb http://download.mono-project.com/repo/debian wheezy main" | sudo tee /etc/apt/sources.list.d/mono-xamarin.list && sudo apt-get update && sudo apt-get install mono-gmcs mono-xbuild mono-dmcs libmono-corlib4.0-cil libmono-system-data-datasetextensions4.0-cil libmono-system-web-extensions4.0-cil libmono-system-management4.0-cil libmono-system-xml-linq4.0-cil cmake dos2unix clang-3.3 libfreetype6-dev libsdl2-dev libgtk-3-dev libmono-microsoft-build-tasks-v4.0-4.0-cil xdg-user-dirs && sudo apt-get install mono-devel &&
+# Installing Dependencies
+echo "Installing dependencies..."
+sudo apt-get install -y build-essential mono-{xbuild,dmcs,gmcs} libmono-{corlib4.0,system-data-datasetextensions4.0-cil,system-web-extensions4.0-cil,system-management4.0-cil,system-xml-linq4.0-cil} cmake dos2unix clang xdg-user-dirs libqt4-dev git
 
-echo Preparing Graphics For Unreal Engine &&
-#Graphics For Unreal Engine
-sudo apt-add-repository ppa:oibaf/graphics-drivers && sudo apt-get update && sudo apt-get dist-upgrade &&
+# Obtain Source
+echo "Obtaining source through Github..."
+git clone https://github.com/3dluvr/UnrealEngine.git
+cd UnrealEngine; ./Setup.sh
 
-echo Get The Source: &&
-#get the source
-git clone https://github.com/3dluvr/UnrealEngine.git && cd UnrealEngine && ./Setup.sh &&
+# Building Unreal 4 Editor
+echo "Building the Unreal 4 Editor..."
+./GenerateProjectFiles.sh
+make SlateViewer
+make ShaderCompileWorker UnrealLightmass UnrealPak UE4Editor
 
-echo Generate Makefiles:&&
-#Generate Makefiles
-find Engine/Source/Programs/AutomationTool -name "*Automation.csproj" -exec sed -i "s/ToolsVersion=\"11.0\"/ToolsVersion=\"4.0\"/g" "{}" \; && export MSBuildToolsVersion=4.0 && ./GenerateProjectFiles.sh &&
-
-echo Cleaning up and Enhancing the Makefile &&
-#Cleaning up and Enhancing the Makefile
-make UE4Editor ARGS=-clean
+# Launch UE4 Editor
+./Engine/Binaries/Linux/UE4Editor

--- a/Unreal_Engine_Install_Script.sh
+++ b/Unreal_Engine_Install_Script.sh
@@ -10,7 +10,7 @@ sudo apt-get install -y build-essential mono-{xbuild,dmcs,gmcs} libmono-{corlib4
 
 # Obtain Source
 echo "Obtaining source through Github..."
-git clone https://github.com/3dluvr/UnrealEngine.git
+git clone https://github.com/EpicGames/UnrealEngine
 cd UnrealEngine; ./Setup.sh
 
 # Building Unreal 4 Editor


### PR DESCRIPTION
It is required that the user must create an account at Unreal and link their GitHub profile on their Unreal profile. After that, they must accept the invite from Unreal in GitHub to gain access to Unreal's private repositories.

Make note that no external repositories are needed. I did read that you may need to 'comment out the line with -Wall -Werror in the .cs file of the c-sharp builder' in order to build the project with the default version of clang shipping in Ubuntu 15.04 -- Clang 3.6.

Source: https://techpromad.wordpress.com/2015/03/14/running-unreal-engine-4-on-ubuntu/
